### PR TITLE
#2 issue solution - NAT is updated overtime

### DIFF
--- a/attendance/models.py
+++ b/attendance/models.py
@@ -92,10 +92,13 @@ class Session(models.Model):
         return time_spend_sum
 
     def get_not_assigned_duration(self):
-        if self.duration:
-            return self.duration - self.get_assigned_duration()
-        else:
+        if Swipe.correction_of_swipe: # Need to check this first for corrected IN swipe of active session
             return self.session_duration() - self.get_assigned_duration()
+        else:
+            if self.duration:
+                return self.duration - self.get_assigned_duration()
+            else:
+                return self.session_duration() - self.get_assigned_duration()
 
     def get_not_work_duration(self):
         time_spend_sum = timedelta(0)

--- a/attendance/tests.py
+++ b/attendance/tests.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 from rest_framework import status
 import pytz
 from datetime import date
+from time import sleep
 
 from attendance.views import sessions_month
 from attendance.factories import UserFactory, SwipeFactory, ProjectFactory, ProjectSeparationFactory
@@ -58,6 +59,24 @@ class SessionTestCase(TestCase):
             )
 
 
+
+    def test_NAT_value_of_opened_session_is_updated_overtime_if_IN_swipe_is_corrected(self):
+        user1 = UserFactory()
+        swipe1 = SwipeFactory(user = user1, swipe_type = "IN")        
+        
+        swipe2 = SwipeFactory( # correction of swipe1
+                user = user1,
+                swipe_type = "IN",
+                correction_of_swipe = swipe1,
+                datetime = swipe1.datetime + timedelta(seconds = 1),
+        )
+
+        nat_1 = swipe2.session.get_not_assigned_duration()
+        sleep(1) # sleep creates needed time difference (better method?)
+        nat_2 = swipe2.session.get_not_assigned_duration()
+
+        self.assertNotEqual(nat_1, nat_2)    
+        
     def create_swipe_new_swipe_with_time_offset(self, session, offset_hours, swipe_type):
         """
         For testing purposes, returns  new_swipe, original_swipe tupple


### PR DESCRIPTION
This request solves #2 issue.  

Changed functions:
In attendance/models.py - get_not_assigned_duration()
Solution requires new if statement for IN swipe correction. Possibility of corrected IN swipe has to be checked first.

Changed tests:
Added new test in attendance/models.py - test_NAT_value_of_opened_session_is_updated_overtime_if_IN_swipe_is_corrected
This test requires import of sleep() method from time library. 


